### PR TITLE
Upgrade xml2json, it uses a more recent node-expat

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
         "class-wolperting": "~0.0.6",
         "lodash": "~2.4.1",
         "request": "~2.34.0",
-        "xml2json": "~0.4.0"
+        "xml2json": "~0.9.0"
     }
 }


### PR DESCRIPTION
This upgrades the xml2json dependency, this fixes a compiler error that happens in the node_expat and nan projects that xml2json uses.
